### PR TITLE
GA4とClarityの実装

### DIFF
--- a/website/src/app/services/adet_LP/layout.tsx
+++ b/website/src/app/services/adet_LP/layout.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+import Script from 'next/script';
+
+const GA4_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID;
+const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID;
+
+export default function ADetLpLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      {CLARITY_PROJECT_ID && (
+        <Script id="adet-lp-clarity" strategy="afterInteractive">
+          {`
+            (function(c,l,a,r,i,t,y){
+              c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+              t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+              y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", ${JSON.stringify(CLARITY_PROJECT_ID)});
+          `}
+        </Script>
+      )}
+      {GA4_MEASUREMENT_ID && (
+        <>
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`}
+            strategy="afterInteractive"
+          />
+          <Script id="adet-lp-ga4" strategy="afterInteractive">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){window.dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', ${JSON.stringify(GA4_MEASUREMENT_ID)}, {
+                page_path: window.location.pathname,
+                page_location: window.location.href,
+                page_title: document.title,
+              });
+            `}
+          </Script>
+        </>
+      )}
+      {children}
+    </>
+  );
+}

--- a/website/src/app/services/adet_LP/page.tsx
+++ b/website/src/app/services/adet_LP/page.tsx
@@ -308,6 +308,7 @@ export default function ADetLpPage() {
                       style={inputStyle('name')}
                       autoComplete="name"
                       placeholder="山田 太郎"
+                      data-clarity-mask="true"
                     />
                   </label>
                   <label className={styles.formField}>
@@ -319,6 +320,7 @@ export default function ADetLpPage() {
                       className={styles.formInput}
                       style={inputStyle('kana')}
                       placeholder="ヤマダ タロウ"
+                      data-clarity-mask="true"
                     />
                   </label>
                 </div>
@@ -333,6 +335,7 @@ export default function ADetLpPage() {
                     type="email"
                     autoComplete="email"
                     placeholder="example@company.co.jp"
+                    data-clarity-mask="true"
                   />
                 </label>
                 <div className={styles.formRow}>
@@ -346,6 +349,7 @@ export default function ADetLpPage() {
                       style={inputStyle('company')}
                       autoComplete="organization"
                       placeholder="株式会社サンプル"
+                      data-clarity-mask="true"
                     />
                   </label>
                   <label className={styles.formField}>
@@ -356,6 +360,7 @@ export default function ADetLpPage() {
                       type="tel"
                       autoComplete="tel"
                       placeholder="03-1234-5678"
+                      data-clarity-mask="true"
                     />
                   </label>
                 </div>
@@ -365,6 +370,7 @@ export default function ADetLpPage() {
                     ref={messageRef}
                     className={styles.formTextarea}
                     placeholder="現在の課題や、確認したい内容をご記入ください。"
+                    data-clarity-mask="true"
                   />
                 </label>
                 <button


### PR DESCRIPTION
## 概要

ADeT LPにGA4とMicrosoft Clarityの計測タグを追加。

## 変更内容

- `/services/adet_LP` 専用の `layout.tsx` を追加
- GA4タグを環境変数から読み込むように実装
- Clarityタグを環境変数から読み込むように実装
- フォーム入力欄に `data-clarity-mask="true"` を追加
  - 氏名
  - フリガナ
  - メールアドレス
  - 会社名
  - 電話番号
  - お問い合わせ内容

## 環境変数

以下の環境変数が設定されている場合のみ、各タグを読み込む。

```env
NEXT_PUBLIC_GA4_MEASUREMENT_ID=G-XXXXXXXXXX
NEXT_PUBLIC_CLARITY_PROJECT_ID=xxxxxxxxxx